### PR TITLE
Remove CommonJS example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,7 @@ npm run test
 It can be used in exactly the same way as [a native WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket), with exactly the same API.
 
 ```js
-// ES2015
 import BoomerangSocket from "boomerang-socket";
-
-// ES5
-const BoomerangSocket = require("boomerang-socket");
 
 const socket = new BoomerangSocket("wss://localhost:8080");
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boomerang-socket",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A simple WebSocket wrapper with automatic reconnection",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
### Problem

- The production bundle is not compiling to  CommonJS.
- Users cannot import the package using the `require` syntax.

### Solution

- Remove the CommonJS example from `README.md`.
- Refactor the build config in a separate PR.