### PR TITLE
Remove window as the exclusive context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "boomerang-socket",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boomerang-socket",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A simple WebSocket wrapper with automatic reconnection",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,7 +7,6 @@ export default {
     file: "lib/index.js",
     format: "cjs",
   },
-  context: "window",
   plugins: [
     typescript({
       clean: true,

--- a/src/EventListeners/EventListeners.ts
+++ b/src/EventListeners/EventListeners.ts
@@ -21,7 +21,7 @@ export class EventListeners {
     const { type } = e;
 
     if (this.store[type]) {
-      this.store[type].map((cb: EventListener) => cb.call(window, e));
+      this.store[type].map((cb: EventListener) => cb.call(this, e));
     }
   };
 

--- a/src/Reconnector/Reconnector.ts
+++ b/src/Reconnector/Reconnector.ts
@@ -58,7 +58,7 @@ class Reconnector {
 
     this.ws.onopen = this.reconnectSuccessful;
 
-    this.connectTimeout = window.setTimeout(
+    this.connectTimeout = setTimeout(
       () => this.ws.close(),
       this.options.connectTimeout
     );
@@ -67,7 +67,7 @@ class Reconnector {
   }
 
   private reconnect() {
-    this.reconnectTimeout = window.setTimeout(
+    this.reconnectTimeout = setTimeout(
       this.reconnectUnsuccessful,
       this.backoff
     );
@@ -81,8 +81,8 @@ class Reconnector {
   }
 
   private reconnectSuccessful(e: Event) {
-    window.clearTimeout(this.connectTimeout);
-    window.clearTimeout(this.reconnectTimeout);
+    clearTimeout(this.connectTimeout);
+    clearTimeout(this.reconnectTimeout);
 
     delete this.connectTimeout;
     delete this.reconnectTimeout;
@@ -98,7 +98,7 @@ class Reconnector {
 
   private reconnectUnsuccessful(e: Event) {
     if (this.attempts < 1) {
-      window.clearTimeout(this.reconnectTimeout);
+      clearTimeout(this.reconnectTimeout);
 
       delete this.reconnectTimeout;
 


### PR DESCRIPTION
### Problem

- To make the package work in NodeJS, a user has to assign `window` to `global`.

### Solution

- Remove `window` as the exclusive context.
